### PR TITLE
Fix typo on setup/require

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use {
   "zbirenbaum/copilot-cmp",
   after = { "copilot.lua" },
   config = function ()
-    require("copilot-cmp").setup()
+    require("copilot_cmp").setup()
   end
 },
 ```
@@ -47,14 +47,14 @@ Set the `method` field to `getCompletionsCycling` if you are having issues. getP
 
 ```lua
 -- Recommended
-require("copilot-cmp").setup {
+require("copilot_cmp").setup {
   method = "getCompletionsCycling",
 },
 ```
 
 ```lua
 -- Not Currently Recommended
-require("copilot-cmp").setup {
+require("copilot_cmp").setup {
   method = "getPanelCompletions",
 },
 ```


### PR DESCRIPTION
The package is named `copilot_cmp` not `copilot-cmp`, the example require/setup on the README is failing.