### PR TITLE
Fix syntax issue in default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ These are the default options for copilot-cmp which can be configured via the se
   force_autofmt = false,
   formatters = {
     label = require("copilot_cmp.format").format_label_text,
-    insert_text = require("copilot_cmp.format").format_label_text
+    insert_text = require("copilot_cmp.format").format_label_text,
     preview = require("copilot_cmp.format").deindent,
   },
 }


### PR DESCRIPTION
Sorry to bother with a typo but I noticed it while installing the plugin.