### PR TITLE
fix: remove trim indent for nvim-cmp confirm

### DIFF
--- a/lua/copilot_cmp/completion_functions.lua
+++ b/lua/copilot_cmp/completion_functions.lua
@@ -23,12 +23,6 @@ end
 
 local format_completions = function(completions, ctx)
   local format_item = function(item)
-    -- get the start point after indent
-    local trim_text = item.text:gsub("^%s*", "")
-    local indent_offset = #item.text - #trim_text
-    -- set the start char to the indent offset to fix matching
-    item.range.start.character = indent_offset
-
     if methods.fix_pairs then
       item.text = handle_suffix(item.text, ctx.cursor_after_line)
       item.displayText = handle_suffix(item.displayText, ctx.cursor_after_line)
@@ -49,8 +43,7 @@ local format_completions = function(completions, ctx)
         kind_text = 'Copilot',
       },
       textEdit = {
-        -- use trim text here so it doesn't add extra indent
-        newText = trim_text,
+        newText = item.text,
         insert = multi_line.insert,
         replace = multi_line.replace,
       },


### PR DESCRIPTION
I encountered some issues with auto-completion. nvim-cmp was incorrectly truncating and completing, and after investigation, I found that trimming was being done when returning Copilot data. This caused an error judgment in [nvim-cmp core.lua at line 377](https://github.com/hrsh7th/nvim-cmp/blob/main/lua/cmp/core.lua#L377). It would consider the completion word as part of the prefix. The following screenshot demonstrates this error.

Step1.

![e2a1db10b585e33b8b1d73d5fa99f762](https://github.com/zbirenbaum/copilot-cmp/assets/25793618/cd70df56-78bf-4d37-8fea-3d3be36dd920)

Step2.

![de477a119b5143c04e9e1aef30d5abc9](https://github.com/zbirenbaum/copilot-cmp/assets/25793618/fec69e03-bd3b-4a98-a3d0-f41201fed566)
