### PR TITLE
Add tab indent detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,6 @@ The configurable options for this plugin are as follows:
 {
   event = { "InsertEnter", "LspAttach" },
   fix_pairs = true,
-  relative_indent = function ()
-    return vim.o.shiftwidth
-  end
 }
 ```
 ##### event
@@ -181,6 +178,3 @@ Copilot might try to account for the `'` and `)` and complete it with this:
 `print('hello`
 
 This is not good behavior for consistency reasons and will just end up deleting the two ending characters. This option fixes that. Don't turn this off unless you are having problems with pairs and believe this might be causing them.
-
-##### relative_indent
-The relative_indent function tells copilot-cmp what the correct number of spaces for a single indent level is. If copilot returns a completion using 4 spaces per indent, but you have 2 spaces per indent in your editor, the completion in your menu will correctly return two spaces.

--- a/lua/copilot_cmp/completion_functions.lua
+++ b/lua/copilot_cmp/completion_functions.lua
@@ -5,11 +5,9 @@ local api = require("copilot.api")
 -- local test = require('copilot_cmp.test_format')
 
 local methods = {
-  id = 0,
-  fix_pairs = true,
-  relative_indent = function ()
-    return vim.o.shiftwidth
-  end
+  opts = {
+    fix_pairs = true,
+  }
 }
 
 local function handle_suffix(text, suffix)
@@ -27,12 +25,12 @@ end
 
 local format_completions = function(completions, ctx)
   local format_item = function(item)
-    if methods.fix_pairs then
+    if methods.opts.fix_pairs then
       item.text = handle_suffix(item.text, ctx.cursor_after_line)
       item.displayText = handle_suffix(item.displayText, ctx.cursor_after_line)
     end
 
-    local multi_line = format.to_multi_line(item, ctx, methods.relative_indent())
+    local multi_line = format.to_multi_line(item, ctx)
 
     return {
       copilot = true, -- for comparator, only availiable in panel, not cycling
@@ -79,10 +77,7 @@ methods.getCompletionsCycling = function (self, params, callback)
 end
 
 methods.init = function (completion_method, opts)
-  methods.existing_matches = {}
-  methods.id = 0
-  methods.fix_pairs = opts.fix_pairs
-  methods.relative_indent = opts.relative_indent
+  methods.opts.fix_pairs = opts.fix_pairs
   return methods[completion_method]
 end
 

--- a/lua/copilot_cmp/format.lua
+++ b/lua/copilot_cmp/format.lua
@@ -45,7 +45,6 @@ end
 
 format.add_indent = function(text, user_indent, indent_level)
   if not indent_level or indent_level == 0 then return text end
-  print(user_indent, indent_level)
 
   local lines = format.split(text, '\n')
   local indent_str = string.rep(user_indent, indent_level)

--- a/lua/copilot_cmp/format.lua
+++ b/lua/copilot_cmp/format.lua
@@ -6,7 +6,7 @@ local label_text = function (text)
   local shorten = function (str)
     local short_prefix = string.sub(str, 0, 20)
     local short_suffix = string.sub(str, string.len(str)-15, string.len(str))
-    local delimiter =  " ... "
+    local delimiter = " ... "
     return short_prefix .. delimiter .. short_suffix
   end
   text = text:gsub("^%s*", "")
@@ -26,29 +26,29 @@ format.get_newline_char = function (text)
 end
 
 -- deindents all lines and sets relative indent level to indent_level spaces
-format.deindent = function(text, rel_indent_level)
+format.deindent = function(text, user_indent)
   local indent = string.match(text, '^%s*')
   if not indent then return text end
 
   local deindented = string.gsub(string.gsub(string.gsub(text, '^' .. indent, ''), '\n' .. indent, '\n'), '[\r|\n]$', '')
-  local rel_indent = string.rep(' ', rel_indent_level)
 
-  if #indent == 0  or not rel_indent or rel_indent == indent then
+  if #indent == 0 or not user_indent or user_indent == indent then
     return deindented
   end
 
   local lines = format.split(deindented, '\n')
   for k, v in ipairs(lines) do
-    lines[k] = string.gsub(v, '^' .. indent, rel_indent)
+    lines[k] = string.gsub(v, '^' .. indent, user_indent)
   end
   return table.concat(lines, '\n')
 end
 
-format.add_indent = function(text, indent_level)
+format.add_indent = function(text, user_indent, indent_level)
   if not indent_level or indent_level == 0 then return text end
+  print(user_indent, indent_level)
 
   local lines = format.split(text, '\n')
-  local indent_str = string.rep(' ', indent_level)
+  local indent_str = string.rep(user_indent, indent_level)
   for k, v in ipairs(lines) do
     lines[k] = indent_str .. v
   end
@@ -76,18 +76,49 @@ format.get_indent_offset = function(text)
   return #text - #format.remove_leading_whitespace(text)
 end
 
-format.to_multi_line = function (item, ctx, rel_indent_level)
+-- format.detect_indent_char = function(text)
+--   local lines = format.split(text, '\n')
+--   local indent = format.get_indent_string(lines[1])
+--   for _, line in ipairs(lines) do
+--     local indent = format.get_indent_string(line)
+--     if indent then
+--       return string.sub(indent, 1, 1)
+--     end
+--   end
+  -- default to space if no indent detected
+--   return ' '
+-- end
+
+format.to_multi_line = function (item, ctx)
   -- get indent on line before cursor
   local indent_offset = format.get_indent_offset(ctx.cursor_before_line)
+  local user_indent = string.match(ctx.cursor_before_line, '^%s')
 
-  -- deindent everything and set all relative indents to `indent_width_fn` spaces
-  local preview = format.deindent(item.text, rel_indent_level)
+  -- if there is no indent on line before cursor, detect via expandtab settings
+  -- have to do this to correcly force compliance with shiftwidth for multilines
+  if user_indent == nil then
+    user_indent = vim.bo.expandtab and ' ' or '\t'
+  end
+
+  -- if tabs , indent offset is the same as indent level
+  local indent_level = indent_offset
+  -- if spaces, force compliance with shiftwidth
+  if user_indent == ' ' then
+    user_indent = string.rep(' ', vim.o.shiftwidth)
+    indent_level = math.floor(indent_offset/vim.o.shiftwidth)
+  end
+
+  -- deindent everything and set all relative indents vim.o.shiftwidth spaces or one tab char
+  local preview = format.deindent(item.text, user_indent)
+  local text = preview
 
   -- add indent equal to whitespace before cursor to every line
-  local text = format.add_indent(preview, indent_offset)
+  if user_indent ~= nil then
+    text = format.add_indent(preview, user_indent, indent_level)
+  end
 
   -- get abbreviated label
-  local label =  label_text(text)
+  local label = label_text(text)
   local splitText = format.split(text)
   local offset = {
     start = {

--- a/lua/copilot_cmp/init.lua
+++ b/lua/copilot_cmp/init.lua
@@ -12,9 +12,7 @@ local M = {
 local default_opts = {
   event = { "InsertEnter", "LspAttach" },
   fix_pairs = true,
-  relative_indent = function ()
-    return vim.o.shiftwidth
-  end
+  indent_char =  '\t',
 }
 
 M._on_insert_enter = function(opts)


### PR DESCRIPTION
The improved indentation validation introduced in #92 unfortunately broke tab completion, this will autodetect which to use by doing the following

1. if there is whitespace at the start of the line before the cursor already, use tabs when that whitespace has a tab char, or vim.o.shiftwidth space chars per indent when that whitespace contains spaces.
2. If there is no whitespace at the start of the cursor line, use tabs when vim.bo.expandtab is set to false, and the same number of spaces per indent as above when it is set to true

Overall this should be an improvement over prior releases for tabs since it won't rely on copilot correctly detecting and using the right indent char, and will instead force compliance with whichever indentation method your editor is set up to use