### PR TITLE
Fix empty-line completion

### DIFF
--- a/lua/copilot_cmp/comparators.lua
+++ b/lua/copilot_cmp/comparators.lua
@@ -1,15 +1,18 @@
 local comparators = {}
 
-comparators.score = function (entry1, entry2)
-  if entry1.score and entry2.score then
-    return entry1.score > entry2.score
+comparators.score = function(entry1, entry2)
+  local diff = (entry1.completion_item.copilot and 1.2 * entry1.score or entry1.score)
+    - (entry2.completion_item.copilot and 1.2 * entry2.score or entry2.score)
+  if diff < 0 then
+    return false
   end
+  return diff > 0 or nil
 end
 
-comparators.prioritize = function (entry1, entry2)
-  if entry1.copilot and not entry2.copilot then
+comparators.prioritize = function(entry1, entry2)
+  if entry1.completion_item.copilot and not entry2.completion_item.copilot then
     return true
-  elseif entry2.copilot and not entry1.copilot then
+  elseif entry2.completion_item.copilot and not entry1.completion_item.copilot then
     return false
   end
 end

--- a/lua/copilot_cmp/completion_functions.lua
+++ b/lua/copilot_cmp/completion_functions.lua
@@ -5,31 +5,36 @@ local api = require("copilot.api")
 local methods = {
   opts = {
     fix_pairs = true,
-  }
+  },
 }
 
-methods.getCompletionsCycling = function (self, params, callback)
+methods.getCompletionsCycling = function(self, params, callback)
   local respond_callback = function(err, response)
-
     if err or not response or not response.completions then
-      return callback({isIncomplete = false, items = {}})
+      return callback({ isIncomplete = false, items = {} })
     end
 
+    local indent = params.context.cursor_before_line:find("%S") or 1
+
     local items = vim.tbl_map(function(item)
-      return format.format_item(item, params.context, methods.opts)
+      local ret = format.format_item(item, params.context, methods.opts)
+
+      ret.textEdit.insert.start.character = ret.textEdit.insert.start.character + indent - 1
+      ret.textEdit.newText = ret.textEdit.newText:sub(indent)
+      ret.textEdit.insert["end"].character = ret.textEdit.insert.start.character
+      return ret
     end, vim.tbl_values(response.completions))
 
     return callback({
       isIncomplete = false,
-      items = items
+      items = items,
     })
   end
 
   api.get_completions_cycling(self.client, util.get_doc_params(), respond_callback)
-  return callback({isIncomplete = true, items = {}})
 end
 
-methods.init = function (completion_method, opts)
+methods.init = function(completion_method, opts)
   methods.opts.fix_pairs = opts.fix_pairs
   return methods[completion_method]
 end

--- a/lua/copilot_cmp/completion_functions.lua
+++ b/lua/copilot_cmp/completion_functions.lua
@@ -21,7 +21,9 @@ methods.getCompletionsCycling = function(self, params, callback)
 
       ret.textEdit.insert.start.character = ret.textEdit.insert.start.character + indent - 1
       ret.textEdit.newText = ret.textEdit.newText:sub(indent)
-      ret.textEdit.insert["end"].character = ret.textEdit.insert.start.character
+      if ret.textEdit.insert["end"].character < ret.textEdit.insert.start.character then
+        ret.textEdit.insert["end"].character = ret.textEdit.insert.start.character
+      end
       return ret
     end, vim.tbl_values(response.completions))
 

--- a/lua/copilot_cmp/completion_functions.lua
+++ b/lua/copilot_cmp/completion_functions.lua
@@ -11,7 +11,7 @@ local methods = {
 methods.getCompletionsCycling = function(self, params, callback)
   local respond_callback = function(err, response)
     if err or not response or not response.completions then
-      return callback({ isIncomplete = false, items = {} })
+      return callback({ isIncomplete = true, items = {} })
     end
 
     local indent = params.context.cursor_before_line:find("%S") or 1
@@ -26,7 +26,7 @@ methods.getCompletionsCycling = function(self, params, callback)
     end, vim.tbl_values(response.completions))
 
     return callback({
-      isIncomplete = false,
+      isIncomplete = true,
       items = items,
     })
   end

--- a/lua/copilot_cmp/source.lua
+++ b/lua/copilot_cmp/source.lua
@@ -3,11 +3,11 @@ local source = {
 }
 
 source.get_trigger_characters = function()
-  return {'.'}
+  return { ".", " ", "\t" }
 end
 
 -- executes before selection
-source.resolve = function (self, completion_item, callback)
+source.resolve = function(self, completion_item, callback)
   for _, fn in ipairs(self.executions) do
     completion_item = fn(completion_item)
   end
@@ -33,7 +33,7 @@ source.is_available = function(self)
   return true
 end
 
-source.execute = function (self, completion_item, callback)
+source.execute = function(self, completion_item, callback)
   callback(completion_item)
 end
 
@@ -41,12 +41,12 @@ source.new = function(client, opts)
   local completion_functions = require("copilot_cmp.completion_functions")
 
   local self = setmetatable({
-    timer = vim.loop.new_timer()
+    timer = vim.loop.new_timer(),
   }, { __index = source })
 
   self.client = client
   self.request_ids = {}
-  self.complete = completion_functions.init('getCompletionsCycling', opts)
+  self.complete = completion_functions.init("getCompletionsCycling", opts)
 
   return self
 end

--- a/lua/copilot_cmp/source.lua
+++ b/lua/copilot_cmp/source.lua
@@ -2,10 +2,6 @@ local source = {
   executions = {},
 }
 
-function source:get_keyword_pattern()
-  return '.'
-end
-
 source.get_trigger_characters = function()
   return {'.'}
 end


### PR DESCRIPTION
There are more fixes to be done, but I will leave those just in my fork to not clutter the diff so much.

This is also not the prettiest fix, but it works. Though I do intend (when I have the time) to make it cleaner and simplify the prefix issue.

After digging into these empty line issues a little bit more, I managed to fully fix it. Here are the conclusions I've come to when figuring out what's most likely going on:
1. no suggestions when on a line without any indentation
   - no idea what indentation had to do with it (maybe less processing time because there was no current line context)
   - callback with results was called before the completion request method finished itself (calling back with an empty table)
   - -> completion was overriden by an empty table
   - ie. race condition
2. no suggestions on indented lines after a couple re-completions
   - still not sure why any came up but then stopped showing up
   - `get_keyword_pattern()` returned `.` -> it requied any character
   - `cmp` seems to consider empty lines as fitting the pattern, but not indented ones
   - returning empty string didn't help, but `cmp_tabnine` didn't have this issue and it also turned out that it didn't have this method either
3. still no suggestions on indented lines
   - `cmp` seems to prohibit changing the text before the cursor, where line indentation is
   - simmilar issue as (2.) - indented parts of lines are considered non-existent by cmp
   - after removing the indentation from all suggestions and ofsetting them by the indentation amount, all works fine
4. comparators do nothing
   - comparators receive a different structure, where is a lot more about the completion, than just the text itself
   - the `copilot` atribute was in a deeper nested table, so the comparator was always accessing `nil`