### PR TITLE
update get_active_clients to get_clients

### DIFF
--- a/lua/copilot_cmp/init.lua
+++ b/lua/copilot_cmp/init.lua
@@ -17,7 +17,7 @@ local default_opts = {
 M._on_insert_enter = function(opts)
 
   local find_buf_client = function()
-    for _, client in ipairs(vim.lsp.get_active_clients()) do
+    for _, client in ipairs(vim.lsp.get_clients()) do
       if client.name == "copilot" then return client end
     end
   end

--- a/lua/copilot_cmp/source.lua
+++ b/lua/copilot_cmp/source.lua
@@ -24,7 +24,7 @@ source.is_available = function(self)
     return false
   end
   -- client is not attached to current buffer.
-  local active_clients = vim.lsp.get_active_clients({ bufnr = vim.api.nvim_get_current_buf() })
+  local active_clients = vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })
   local active_copilot_client = vim.tbl_filter(function(client)
     return client.id == self.client.id
   end, active_clients)


### PR DESCRIPTION
I checked the source code and this should be equivalent. Using the deprecated name gives me an error message whenever I open vim.