### PR TITLE
resolving deprecation warning on client:is_stopped

### DIFF
--- a/lua/copilot_cmp/source.lua
+++ b/lua/copilot_cmp/source.lua
@@ -7,11 +7,11 @@ function source:get_keyword_pattern()
 end
 
 source.get_trigger_characters = function()
-  return {'.'}
+  return { '.' }
 end
 
 -- executes before selection
-source.resolve = function (self, completion_item, callback)
+source.resolve = function(self, completion_item, callback)
   for _, fn in ipairs(self.executions) do
     completion_item = fn(completion_item)
   end
@@ -20,12 +20,12 @@ end
 
 source.is_available = function(self)
   -- client is stopped.
-  if self.client.is_stopped() or not self.client.name == "copilot" then
+  if self.client:is_stopped() or not self.client.name == "copilot" then
     return false
   end
 
 
-  local get_source_client = function ()
+  local get_source_client = function()
     if vim.lsp.get_clients == nil then
       return vim.lsp.get_active_clients({
         bufnr = vim.api.nvim_get_current_buf(),
@@ -41,7 +41,7 @@ source.is_available = function(self)
   return next(get_source_client()) ~= nil
 end
 
-source.execute = function (_, completion_item, callback)
+source.execute = function(_, completion_item, callback)
   callback(completion_item)
 end
 


### PR DESCRIPTION
Deprecation warning began with release of nvim `0.11`.

I hope minor formatting changes alright. My automatic lua formatting triggered it. I see the conventions are followed elsewhere in the file, so I kept them.