### PR TITLE
fix(source.lua): correct method call for client check

### DIFF
--- a/lua/copilot_cmp/source.lua
+++ b/lua/copilot_cmp/source.lua
@@ -20,7 +20,7 @@ end
 
 source.is_available = function(self)
   -- client is stopped.
-  if self.client.is_stopped() or not self.client.name == "copilot" then
+  if self.client:is_stopped() or not self.client.name == "copilot" then
     return false
   end
 


### PR DESCRIPTION
Updated the `is_stopped` method call to use colon syntax in `source.is_available` function. This ensures proper invocation of the method and avoids potential runtime errors.


Previous of this change I got the following error:

```bash
WARNING client.is_stopped is deprecated. Feature will be remove in Nvim 0.13
```