### PR TITLE
Fix deprecated errors + get multiple completions in one time

### DIFF
--- a/lua/copilot_cmp/completion_functions.lua
+++ b/lua/copilot_cmp/completion_functions.lua
@@ -8,11 +8,10 @@ local methods = {
   }
 }
 
-methods.getCompletions = function (self, params, callback)
+methods.getCompletions = function(self, params, callback)
   local respond_callback = function(err, response)
-
     if err or not response or not response.completions then
-      return callback({isIncomplete = false, items = {}})
+      return callback({ isIncomplete = false, items = {} })
     end
 
     local items = vim.tbl_map(function(item)
@@ -25,11 +24,11 @@ methods.getCompletions = function (self, params, callback)
     })
   end
 
-  api.get_completions(self.client, util.get_doc_params(), respond_callback)
-  return callback({isIncomplete = true, items = {}})
+  api.get_completions_cycling(self.client, util.get_doc_params(), respond_callback)
+  return callback({ isIncomplete = true, items = {} })
 end
 
-methods.init = function (completion_method, opts)
+methods.init = function(completion_method, opts)
   methods.opts.fix_pairs = opts.fix_pairs
   return methods[completion_method]
 end

--- a/lua/copilot_cmp/source.lua
+++ b/lua/copilot_cmp/source.lua
@@ -20,7 +20,7 @@ end
 
 source.is_available = function(self)
   -- client is stopped.
-  if self.client.is_stopped() or not self.client.name == "copilot" then
+  if self.client:is_stopped() or not self.client.name == "copilot" then
     return false
   end
 


### PR DESCRIPTION
This branch gets rid of deprecation errors and allows copilot-cmp to receive multiple suggestions.

Can't wait for the merge (source repo is pretty dead)? require this auto completion source instead:

```
{
 ...
 {
    'hendrikpetertje/copilot-cmp',
    branch = 'fix-deprecated-errors'
  }
}
```